### PR TITLE
Feature: auto update time

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,14 +132,17 @@ Configuration of the application. See example configuration [here](#example).
 
 ### General
 
-| Parameter                                | Description                                     | Default     |
-|------------------------------------------|-------------------------------------------------|-------------|
-| `health_check` (Optional)                | Enable health check                             | True        |
-| `health_check_interval` (Optional)       | Interval in seconds between health check writes | 60.0        |
-| `health_check_dir` (Optional)            | Directory to store health check files           | "~/.plejd/" |
-| `health_check_bt_file` (Optional)        | File name for Bluetooth health check            | "bluetooth" |
-| `health_check_mqtt_file` (Optional)      | File name for MQTT health check                 | "mqtt"      |
-| `health_check_heartbeat_file` (Optional) | File name for heartbeat file                    | "heartbeat" |
+| Parameter                                | Description                                                                             | Default     |
+|------------------------------------------|-----------------------------------------------------------------------------------------|-------------|
+| `health_check` (Optional)                | Enable health check                                                                     | True        |
+| `health_check_interval` (Optional)       | Interval in seconds between health check writes                                         | 60.0        |
+| `health_check_dir` (Optional)            | Directory to store health check files                                                   | "~/.plejd/" |
+| `health_check_bt_file` (Optional)        | File name for Bluetooth health check                                                    | "bluetooth" |
+| `health_check_mqtt_file` (Optional)      | File name for MQTT health check                                                         | "mqtt"      |
+| `health_check_heartbeat_file` (Optional) | File name for heartbeat file                                                            | "heartbeat" |
+| `time_update_interval` (Optional)        | Interval in seconds between updating Plejd time                                         | 3600.0      |
+| `time_update_threshold` (Optional)       | Time difference in seconds between Plejd time and local time before updating Plejd time | 10.0        |
+| `time_use_sys_time` (Optional)           | Whether or not to use system time instead of NTP time **NOT USED YET!**                 | True        |
 
 ### API
 
@@ -155,13 +158,19 @@ Configuration of the application. See example configuration [here](#example).
 
 ### MQTT
 
-| Parameter                        | Description                     | Default         |
-|----------------------------------|---------------------------------|-----------------|
-| `host` (Optional)                | Address of the host MQTT broker | "localhost"     |
-| `port` (Optional)                | Port of the MQTT host           | 1883            |
-| `user` (Optional)                | MQTT user name                  | None            |
-| `password` (Optional)            | Password of the MQTT user       | None            |
-| `ha_discovery_prefix` (Optional) | Home assistant discovery prefix | "homeassistant" |
+| Parameter                     | Description                                                               | Default         |
+|-------------------------------|---------------------------------------------------------------------------|-----------------|
+| `host` (Optional)             | MQTT broker host                                                          | "localhost"     |
+| `port` (Optional)             | MQTT broker port                                                          | 1883            |
+| `username` (Optional)         | MQTT broker username                                                      | None            |
+| `password` (Optional)         | MQTT broker password                                                      | None            |
+| `client_name` (Optional)      | MQTT client name                                                          | None            |
+| `use_tls` (Optional)          | Whether or not to use TLS                                                 | False           |
+| `tls_key` (Optional)          | TLS key file                                                              | None            |
+| `tls_certfile` (Optional)     | TLS certificate file                                                      | None            |
+| `tls_ca_cert` (Optional)      | TLS CA certificate file                                                   | None            |
+| `discovery_prefix` (Optional) | The root of the topic tree where HA is listening for messages             | "homeassistant" |
+| `state_prefix` (Optional)     | The root of the topic tree ha-mqtt-discovery publishes its state messages | "hmd"           |
 
 ### BLE
 

--- a/plejd_mqtt_ha/mdl/settings.py
+++ b/plejd_mqtt_ha/mdl/settings.py
@@ -125,3 +125,11 @@ class PlejdSettings(BaseModel):
     """File name for MQTT health check"""
     health_check_hearbeat_file: str = "heartbeat"
     """File name for heartbeat file"""
+
+    time_update_interval: float = 60.0
+    """Interval in seconds between updating Plejd time"""
+    time_update_threshold: float = 10.0
+    """Time difference in seconds between Plejd time and local time before updating Plejd time"""
+    time_use_sys_time: bool = True
+    """Whether or not to use system time instead of NTP time"""
+    # TODO: Add ntp server option

--- a/plejd_mqtt_ha/mdl/settings.py
+++ b/plejd_mqtt_ha/mdl/settings.py
@@ -126,7 +126,7 @@ class PlejdSettings(BaseModel):
     health_check_hearbeat_file: str = "heartbeat"
     """File name for heartbeat file"""
 
-    time_update_interval: float = 60.0
+    time_update_interval: float = 60.0 * 60.0  # 1 hour
     """Interval in seconds between updating Plejd time"""
     time_update_threshold: float = 10.0
     """Time difference in seconds between Plejd time and local time before updating Plejd time"""

--- a/plejd_mqtt_ha/plejd.py
+++ b/plejd_mqtt_ha/plejd.py
@@ -171,10 +171,13 @@ async def _update_plejd_time(
                     await bt_client.set_plejd_time(ble_address, current_sys_time)
                     logging.info(f"Updated Plejd time using device {device._device_info.name}")
                 else:
-                    logging.info("Plejd time is already up to date")
+                    logging.info(
+                        f"Used device {device._device_info.name} to tell Plejd time is already up"
+                        "to date"
+                    )
             except PlejdBluetoothError as err:
                 logging.error(
-                    f"Error {err} updating Plejd time using device {device._device_info.name},"
+                    f"Error {err} updating Plejd time using device {device._device_info.name}, "
                     "trying next device"
                 )
                 continue

--- a/plejd_mqtt_ha/plejd.py
+++ b/plejd_mqtt_ha/plejd.py
@@ -18,6 +18,7 @@ Responsible for starting loading settings, performing health checks and creating
 """
 
 import asyncio
+import datetime
 import logging
 import logging.handlers
 import os
@@ -26,7 +27,7 @@ import time
 
 import yaml
 from plejd_mqtt_ha import constants
-from plejd_mqtt_ha.bt_client import BTClient
+from plejd_mqtt_ha.bt_client import BTClient, PlejdBluetoothError
 from plejd_mqtt_ha.mdl.combined_device import (
     BTDeviceError,
     CombinedDevice,
@@ -134,11 +135,51 @@ async def _run(config: str, log_level: str, log_file: str) -> None:
         return
     logging.info(f"Created {len(discovered_devices)} Plejd devices.. [OK]")
 
-    heartbeat_task = asyncio.create_task(
-        write_health_data(plejd_settings, discovered_devices)
-    )  # Create heartbeat task
+    heartbeat_task = asyncio.create_task(write_health_data(plejd_settings, discovered_devices))
+    update_time_task = asyncio.create_task(_update_plejd_time(plejd_settings, discovered_devices))
 
-    await heartbeat_task  # Wait indefinitely for the heartbeat task
+    await asyncio.gather(heartbeat_task, update_time_task)  # Wait indefinitely for the tasks
+
+
+async def _update_plejd_time(
+    plejd_settings: PlejdSettings, discovered_devices: list[CombinedDevice]
+) -> None:
+    """Update Plejd time continously.
+
+    Parameters
+    ----------
+    plejd_settings : PlejdSettings
+        Settings
+    discovered_devices : list[CombinedDevice]
+        List of discovered devices
+    """
+    bt_client = discovered_devices[0]._plejd_bt_client
+    while True:  # Run forever
+        for device in discovered_devices:
+            try:
+                ble_address = device._device_info.ble_address
+                current_plejd_time = await bt_client.get_plejd_time(ble_address)
+
+                if plejd_settings.time_use_sys_time:
+                    current_sys_time = datetime.datetime.now()
+                else:
+                    current_sys_time = None  # TODO: not implemented
+
+                if abs(current_plejd_time - current_sys_time) > datetime.timedelta(
+                    seconds=plejd_settings.time_update_interval
+                ):
+                    await bt_client.set_plejd_time(ble_address, current_sys_time)
+                    logging.info(f"Updated Plejd time using device {device._device_info.name}")
+                else:
+                    logging.info("Plejd time is already up to date")
+            except PlejdBluetoothError as err:
+                logging.error(
+                    f"Error {err} updating Plejd time using device {device._device_info.name},"
+                    "trying next device"
+                )
+                continue
+
+            await asyncio.sleep(plejd_settings.time_update_interval)
 
 
 async def write_health_data(


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description
Plejd now updates its internal clock automatically

<!--- Describe your changes in detail -->

Three settings are exposed to this change.
It is possible to set the interval between time checks
It is possible to set the time diff threshhold, ie how much shall the clock diff before updating it
A third, but not yet used, option to use an external NTP server

Fixes #5 

# License Acceptance

- [x] This repository is Apache version 2.0 licensed and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.

# Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist

- [x] I have read through the contributing guidelines
- [x] My code follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
