### PR TITLE
Bugfix: Unique ids for all device triggers

### DIFF
--- a/plejd_mqtt_ha/mdl/combined_device.py
+++ b/plejd_mqtt_ha/mdl/combined_device.py
@@ -371,8 +371,8 @@ class CombinedDeviceTrigger(CombinedDevice[BTDeviceTriggerInfo]):
             subtype = "button_" + str(index % 2) if double_sided else "button"
 
             mqtt_device_trigger_info = DeviceTriggerInfo(
-                name=subtype,
-                unique_id=self._device_info.unique_id + "_" + str(index % 2),
+                name=subtype + "_" + button["type"],  # ie button_0_DirectionUp
+                unique_id=self._device_info.unique_id + "_" + str(index),
                 type=button["type"],
                 subtype=subtype,
                 device=mqtt_device_info,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

# Description
All device triggers now correctly have unique names and ids

# License Acceptance

- [x] This repository is Apache version 2.0 licensed and by making this PR, I am contributing my changes to the repository under the terms of the Apache 2 license.

# Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist

- [x] I have read through the contributing guidelines
- [x] My code follows the style guidelines of this project
- [x] I have made corresponding changes to the documentation
- [x] New and existing unit tests pass locally with my changes
